### PR TITLE
Performance improvement of remove_unnatural()

### DIFF
--- a/protlearn/preprocessing/remove_unnatural.py
+++ b/protlearn/preprocessing/remove_unnatural.py
@@ -36,16 +36,17 @@ def remove_unnatural(X):
     X = check_input(X)
 
     # remove sequences with unnatural amino acids
-    amino_acids = 'ACDEFGHIKLMNPQRSTVWY'
+    amino_acids = set('ACDEFGHIKLMNPQRSTVWY')
     indices = []
     for i, seq in enumerate(X):
         check_alpha(seq) # check if alphabetical      
         # get indices of sequences with unnatural amino acids
         for aa in seq:
-            if aa in set(amino_acids):
+            if aa in amino_acids:
                 pass
             else:
                 indices.append(i)
+                break
 
     # remove sequences by indices
     Y = [i for j, i in enumerate(X) if j not in set(indices)]


### PR DESCRIPTION
I fixed the performance of remove_unnatural().
What I did is as following:
 - Removed casting a amino_acids into a set in the main loop
 - Escaped from the main loop instantly when unnatural letter found

I measured performance using 10000 seqs of length between 10 to 500. About 1000 seqs are unnatural in the dataset.

Original: 2.45 sec
Stop casting: 1.60 sec
Escape: 1.09 sec
Both: 0.27 sec